### PR TITLE
Ft/606503 - Update library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,124 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-05-20
+
+### BREAKING CHANGES
+- `BadRequestFieldsError` constructor parameter `valueParams` changed from `Dictionary<string, object>?` (nullable) to `Dictionary<string, object>` (non-nullable). Code calling this constructor with an explicit `null` will fail to compile.
+- Removed nullable collection (`Dictionary?`) definitions in favor of initializing empty collections.
+
+### ADDED
+- Added comprehensive XML documentation summaries to all public classes, methods, properties, and interfaces.
+- Added a new overload of `BadRequestFieldsError` without a dictionary parameter, defaulting to an empty collection.
+
+### CHANGED
+- `EntityNotFoundError` now explicitly passes an empty dictionary to the base constructor.
+
+### FIXED
+- Fixed malformed XML documentation tags (`<see cref="Result{T}"/>`) in `StringExtension` methods.
+- Fixed incorrect constructor summary in `BadRequestFieldsError` overload.
+
+## [1.2.0] - 2026-01-09
+
+### CHANGED
+- Updated package versions.
+
+## [1.1.0] - 2025-10-22
+
+### ADDED
+- Added `ContainerId` property to `ContainerOption`.
+
+## [1.0.0] - 2025-08-11
+
+### CHANGED
+- Changed `InternalServerError` class from `class` to `sealed`.
+- Updated package version to 1.0.0.
+
+### ADDED
+- Added internal server error option with custom message support.
+
+## [0.9.1] - 2025-02-04
+
+### CHANGED
+- Enhanced property name processing in `EnumExtension`.
+
+## [0.9.0] - 2025-01-03
+
+### ADDED
+- Added `InvalidFieldError` for invalid field result errors.
+
+## [0.8.0] - 2024-11-18
+
+### CHANGED
+- Updated `AppendString` method separator from `-` to `.`.
+
+## [0.7.0] - 2024-10-28
+
+### ADDED
+- Added `EntityUlidInt32` class with external ULID support.
+- Added `Ulid` package dependency.
+
+### CHANGED
+- Renamed `SecondId` property to `ExternalId` in `EntityUlidInt32`.
+
+## [0.6.0] - 2024-09-23
+
+### ADDED
+- Added `LogCreateDto` for creating log entries.
+- Added `AppendString` string extension method.
+
+### CHANGED
+- Refactored `LogDto` structure and properties.
+- Improved `LogDto` data transfer object.
+
+### FIXED
+- Fixed NuGet package packing issues.
+- Fixed message keys for unavailable services.
+
+## [0.5.0] - 2024-09-10
+
+### ADDED
+- Added `ServiceUnavailableError` for service unavailability scenarios.
+- Added new entity type `EntityNullable`.
+
+### FIXED
+- Fixed NuGet package packing configuration.
+
+## [0.4.0] - 2024-05-02
+
+### ADDED
+- Added `EntityNotFoundError` for entity lookup failures.
+- Added `IValidatorGeneric` contract for generic validation.
+
+## [0.3.0] - 2024-03-25
+
+### ADDED
+- Added `EntityInt32` entity type.
+- Added `ResultExtension` methods for FluentResults.
+- Added `StringExtension` utility methods.
+- Added `IntExtension` utility methods.
+- Added `EnumExtension` utility methods.
+- Added `DefaultErrorMessageKeys` constants.
+- Added `StatusCodeMessageKeys` constants.
+- Added `ContextType` and `LogActionType` identifiers.
+- Added `LogDto` and logging contracts.
+- Added `ContainerOption` and `LogServiceOption` configuration options.
+- Added `BadRequestFieldsError` base error class.
+- Added `EmptyFieldError`, `InvalidLengthError`, `InvalidMinValueError` errors.
+- Added `CreatedSuccess`, `NoContentSuccess`, `EmptyResult` success classes.
+- Added `ResourceNotFoundError` and `InternalServerError` errors.
+
+### CHANGED
+- Moved shared domain classes from other libraries to this project.
+- Improved CI/CD pipeline configuration.
+
+## [0.1.0] - 2024-03-25
+
+### ADDED
+- Initial project setup and folder structure.
+- Created base `Entity<T>` abstract class.
+- Added `IEntity` contract interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2025-05-20
+## [2.0.0] - 2026-05-20
 
 ### BREAKING CHANGES
 - `BadRequestFieldsError` constructor parameter `valueParams` changed from `Dictionary<string, object>?` (nullable) to `Dictionary<string, object>` (non-nullable). Code calling this constructor with an explicit `null` will fail to compile.
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EntityNotFoundError` now explicitly passes an empty dictionary to the base constructor.
 
 ### FIXED
+- `HasMinWords` now correctly ignores empty entries caused by multiple spaces.
+- `GetLongOrDefault` now uses `long.TryParse` to safely return 0 for invalid or non-numeric inputs instead of throwing `FormatException`.
 - Fixed malformed XML documentation tags (`<see cref="Result{T}"/>`) in `StringExtension` methods.
 - Fixed incorrect constructor summary in `BadRequestFieldsError` overload.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,172 @@
 # IATec.Shared.Net.Domain
 
-Repository for managing classes shared between .net projects developed at IATec.
+A shared domain library for .NET projects developed at IATec. This package provides common building blocks for domain-driven design, including entities, results, errors, successes, logging models, contracts, and utility extensions used across multiple IATec applications.
+
+## Installation
+
+Install the package via NuGet:
+
+```bash
+dotnet add package IATec.Shared.Domain
+```
+
+Or via Package Manager:
+
+```powershell
+Install-Package IATec.Shared.Domain
+```
+
+## Requirements
+
+- .NET 8.0, .NET 9.0, or .NET 10.0
+
+## Dependencies
+
+- [FluentResults](https://www.nuget.org/packages/FluentResults) (4.0.0)
+- [FluentValidation](https://www.nuget.org/packages/FluentValidation) (12.1.1)
+- [Ulid](https://www.nuget.org/packages/Ulid) (1.4.1)
+
+## Project Structure
+
+### SeedWorks
+Base entity classes for domain models:
+
+| Class | Description |
+|-------|-------------|
+| `Entity<T>` | Abstract base entity with a generic identifier type |
+| `EntityInt32` | Entity with a 32-bit integer identifier |
+| `EntityUlidInt32` | Entity with a 32-bit integer identifier and an external ULID |
+| `EntityNullable` | Entity with a nullable string identifier |
+
+### Results
+Error and success result classes built on top of FluentResults:
+
+#### Errors
+| Class | Description |
+|-------|-------------|
+| `BadRequestFieldsError` | Base class for bad-request field validation errors |
+| `EmptyFieldError` | Error when a required field is empty |
+| `EntityNotFoundError` | Error when an entity is not found |
+| `InternalServerError` | Error for internal server failures |
+| `InvalidFieldError` | Error when a field has an invalid value |
+| `InvalidLengthError` | Error when a field value length is out of range |
+| `InvalidMinValueError` | Error when a field value is below the minimum |
+| `ResourceNotFoundError` | Error when a requested resource is not found |
+| `ServiceUnavailableError` | Error when a service is unavailable |
+
+#### Successes
+| Class | Description |
+|-------|-------------|
+| `CreatedSuccess` | Success result for resource creation |
+| `EmptyResult` | Success result with no content |
+| `NoContentSuccess` | Success result for no-content responses |
+
+### Contracts
+Interfaces defining contracts for common services and patterns:
+
+| Interface | Description |
+|-----------|-------------|
+| `IEntity` | Contract for domain entities |
+| `ILogDispatcher` | Contract for dispatching log entries |
+| `ILogService` | Contract for logging service implementation |
+| `IValidatorGeneric` | Contract for generic validator provider |
+
+### Models
+Data transfer objects for logging:
+
+| Class | Description |
+|-------|-------------|
+| `LogDto` | Log entry data transfer object |
+| `LogCreateDto` | Data transfer object for creating a new log entry |
+
+### Identifies
+Type-safe identifiers for contexts and logging actions:
+
+| Class | Description |
+|-------|-------------|
+| `BaseIdentify` | Abstract base class for identification types |
+| `ContextType` | Context type for categorizing errors (Domain, Application) |
+| `LogActionType` | Log action types (Added, Modified, Deleted) |
+
+### Messages
+Constants for error and status code message keys:
+
+| Class | Description |
+|-------|-------------|
+| `DefaultErrorMessageKeys` | Default error message key constants |
+| `StatusCodeMessageKeys` | Status code message key constants |
+
+### Options
+Configuration option classes:
+
+| Class | Description |
+|-------|-------------|
+| `ContainerOption` | Configuration options for containers |
+| `LogServiceOption` | Configuration options for the logging service |
+
+### Extensions
+Utility extension methods:
+
+| Class | Description |
+|-------|-------------|
+| `EnumExtension` | Extension methods for enum operations |
+| `IntExtension` | Extension methods for integer and date calculations |
+| `ResultExtension` | Extension methods for FluentResults |
+| `StringExtension` | Extension methods for string manipulation |
+
+## Usage Examples
+
+### Entity
+
+```csharp
+using IATec.Shared.Domain.SeedWorks;
+
+public class Product : EntityInt32
+{
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+}
+```
+
+### Error Results
+
+```csharp
+using IATec.Shared.Domain.Results.Errors.Default;
+using IATec.Shared.Domain.Identifies.Contexts;
+
+var error = new EmptyFieldError("Product", "Name", ContextType.Domain);
+```
+
+### Success Results
+
+```csharp
+using IATec.Shared.Domain.Results.Successes.Default;
+
+var success = new CreatedSuccess(123);
+```
+
+### Extensions
+
+```csharp
+using IATec.Shared.Domain.Extensions;
+
+// String extensions
+bool isValid = "hello".IsValid();
+string appended = "root".AppendString("child"); // "root.child"
+
+// Integer extensions
+bool inRange = 5.IsBetween(1, 10);
+int age = birthDate.GetAge();
+
+// Result extensions
+bool isCreated = result.IsCreatedSuccess();
+bool isNotFound = result.IsResourceNotFoundError();
+```
+
+## License
+
+Copyright © IATec Solutions. All rights reserved.
+
+## Contributing
+
+This library is maintained by the IATec | Solution | Platform Team. For issues or contributions, please visit the [GitHub repository](https://github.com/iatecbr/IATec.Shared.Net.Domain).

--- a/src/Contracts/Dispatcher/ILogDispatcher.cs
+++ b/src/Contracts/Dispatcher/ILogDispatcher.cs
@@ -1,7 +1,19 @@
 namespace IATec.Shared.Domain.Contracts.Dispatcher;
 
+/// <summary>
+/// Defines the contract for dispatching log entries.
+/// </summary>
 public interface ILogDispatcher
 {
+    /// <summary>
+    /// Dispatches a log entry asynchronously.
+    /// </summary>
+    /// <param name="source">The source of the log entry.</param>
+    /// <param name="owner">The owner associated with the log entry.</param>
+    /// <param name="action">The action performed.</param>
+    /// <param name="content">Optional content for the log entry.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task DispatchAsync(
         string source,
         string owner,

--- a/src/Contracts/Entities/IEntity.cs
+++ b/src/Contracts/Entities/IEntity.cs
@@ -2,15 +2,38 @@ using IATec.Shared.Domain.Identifies.Base;
 
 namespace IATec.Shared.Domain.Contracts.Entities;
 
+/// <summary>
+/// Defines the contract for a domain entity.
+/// </summary>
 public interface IEntity
 {
+    /// <summary>
+    /// Determines whether the entity identifier is unassigned.
+    /// </summary>
+    /// <returns>True if the identifier is unassigned; otherwise, false.</returns>
     public bool IsUnassigned();
 
+    /// <summary>
+    /// Gets the source type of the entity.
+    /// </summary>
+    /// <returns>The source type identifier, or null if not defined.</returns>
     public BaseIdentify? GetSourceType();
 
+    /// <summary>
+    /// Gets the owner of the entity.
+    /// </summary>
+    /// <returns>A string representing the owner.</returns>
     public string GetOwner();
 
+    /// <summary>
+    /// Gets the content to be logged for this entity.
+    /// </summary>
+    /// <returns>The log content object, or null if not defined.</returns>
     public object? GetLogContent();
 
+    /// <summary>
+    /// Returns a string representation of the entity.
+    /// </summary>
+    /// <returns>A string that represents the entity.</returns>
     public string ToString();
 }

--- a/src/Contracts/Services/Logging/ILogService.cs
+++ b/src/Contracts/Services/Logging/ILogService.cs
@@ -2,7 +2,16 @@ using IATec.Shared.Domain.Models.LoggingAggregate.Dtos;
 
 namespace IATec.Shared.Domain.Contracts.Services.Logging;
 
+/// <summary>
+/// Defines the contract for a logging service.
+/// </summary>
 public interface ILogService
 {
+    /// <summary>
+    /// Sends a log entry asynchronously.
+    /// </summary>
+    /// <param name="log">The log entry to send.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task SendAsync(LogDto log, CancellationToken cancellationToken = default);
 }

--- a/src/Contracts/Validator/IValidatorGeneric.cs
+++ b/src/Contracts/Validator/IValidatorGeneric.cs
@@ -2,7 +2,15 @@ using FluentValidation;
 
 namespace IATec.Shared.Domain.Contracts.Validator;
 
+/// <summary>
+/// Defines a generic validator provider contract.
+/// </summary>
 public interface IValidatorGeneric
 {
+    /// <summary>
+    /// Gets the validator for the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type to validate.</typeparam>
+    /// <returns>The validator instance, or null if not found.</returns>
     IValidator<T>? GetValidator<T>();
 }

--- a/src/Extensions/EnumExtension.cs
+++ b/src/Extensions/EnumExtension.cs
@@ -2,8 +2,18 @@ using System.Linq.Expressions;
 
 namespace IATec.Shared.Domain.Extensions;
 
+/// <summary>
+/// Provides extension methods for enum operations.
+/// </summary>
 public static class EnumExtension
 {
+    /// <summary>
+    /// Converts a property expression to a property identifier name.
+    /// </summary>
+    /// <typeparam name="T">The type containing the property.</typeparam>
+    /// <param name="propertyExpression">The property expression.</param>
+    /// <returns>The processed property identifier name.</returns>
+    /// <exception cref="ArgumentException">Thrown when the expression does not refer to a property.</exception>
     public static string ToPropertyIdName<T>(Expression<Func<T, object>> propertyExpression)
     {
         return propertyExpression.Body switch
@@ -15,10 +25,15 @@ public static class EnumExtension
         };
     }
 
+    /// <summary>
+    /// Processes the property name by replacing "Enum" suffix with "Id" or appending "Id".
+    /// </summary>
+    /// <param name="propertyName">The original property name.</param>
+    /// <returns>The processed property name.</returns>
     private static string ProcessPropertyName(string propertyName)
     {
-        return propertyName.EndsWith("Enum") 
-            ? propertyName.Replace("Enum", "Id") 
+        return propertyName.EndsWith("Enum")
+            ? propertyName.Replace("Enum", "Id")
             : propertyName + "Id";
     }
 }

--- a/src/Extensions/IntExtension.cs
+++ b/src/Extensions/IntExtension.cs
@@ -1,7 +1,19 @@
 ﻿namespace IATec.Shared.Domain.Extensions;
 
+/// <summary>
+/// Provides extension methods for integer and date operations.
+/// </summary>
 public static class IntExtension
 {
+    /// <summary>
+    /// Determines whether the number is within the specified range.
+    /// </summary>
+    /// <param name="num">The number to evaluate.</param>
+    /// <param name="min">The minimum value.</param>
+    /// <param name="max">The maximum value.</param>
+    /// <param name="includeMin">If true, includes the minimum value in the range.</param>
+    /// <param name="includeMax">If true, includes the maximum value in the range.</param>
+    /// <returns>True if the number is within the range; otherwise, false.</returns>
     public static bool IsBetween(this int num,
         int min,
         int max,
@@ -11,16 +23,35 @@ public static class IntExtension
         return IsGreaterThan(num, min, includeMin) && IsLessThan(num, max, includeMax);
     }
 
+    /// <summary>
+    /// Determines whether the value is greater than the specified minimum.
+    /// </summary>
+    /// <param name="value">The value to evaluate.</param>
+    /// <param name="minValue">The minimum value.</param>
+    /// <param name="includeMin">If true, includes the minimum value.</param>
+    /// <returns>True if the value is greater than the minimum; otherwise, false.</returns>
     public static bool IsGreaterThan(int value, int minValue, bool includeMin)
     {
         return (includeMin && value >= minValue) || value > minValue;
     }
 
+    /// <summary>
+    /// Determines whether the value is less than the specified maximum.
+    /// </summary>
+    /// <param name="value">The value to evaluate.</param>
+    /// <param name="maxValue">The maximum value.</param>
+    /// <param name="includeMax">If true, includes the maximum value.</param>
+    /// <returns>True if the value is less than the maximum; otherwise, false.</returns>
     public static bool IsLessThan(int value, int maxValue, bool includeMax)
     {
         return (includeMax && value <= maxValue) || value < maxValue;
     }
 
+    /// <summary>
+    /// Calculates the age based on the birth date.
+    /// </summary>
+    /// <param name="birthDate">The birth date.</param>
+    /// <returns>The age in years, or 0 if the birth date is null.</returns>
     public static int GetAge(this DateTime? birthDate)
     {
         if (birthDate == null) return 0;
@@ -28,6 +59,11 @@ public static class IntExtension
         return new DateTime(DateTime.Now.Subtract((DateTime) birthDate).Ticks).Year - 1;
     }
 
+    /// <summary>
+    /// Calculates the age based on a birth date string.
+    /// </summary>
+    /// <param name="birthDate">The birth date as a string.</param>
+    /// <returns>The age in years, or 0 if parsing fails.</returns>
     public static int GetAge(this string? birthDate)
     {
         if (birthDate == null) return 0;

--- a/src/Extensions/ResultExtension.cs
+++ b/src/Extensions/ResultExtension.cs
@@ -7,20 +7,36 @@ using IATec.Shared.Domain.Results.Successes.Default;
 namespace IATec.Shared.Domain.Extensions;
 
 /// <summary>
-/// Extension for FluentResult
+/// Provides extension methods for FluentResults Result objects.
 /// </summary>
 public static class ResultExtension
 {
+    /// <summary>
+    /// Determines whether the result contains a created success.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has a created success; otherwise, false.</returns>
     public static bool IsCreatedSuccess(this ResultBase result)
     {
         return result.HasSuccess<CreatedSuccess>();
     }
 
+    /// <summary>
+    /// Determines whether the result contains a no-content success.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has a no-content success; otherwise, false.</returns>
     public static bool IsNoContentSuccess(this ResultBase result)
     {
         return result.HasSuccess<NoContentSuccess>();
     }
 
+    /// <summary>
+    /// Determines whether the result is an empty result (null value or no-content success).
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result is empty; otherwise, false.</returns>
     public static bool IsEmptyResult<T>(this Result<T> result)
     {
         return result.IsSuccess
@@ -28,21 +44,41 @@ public static class ResultExtension
                    || result.HasSuccess(x => x.Message.Equals(StatusCodeMessageKeys.NoContentMessageKey)));
     }
 
+    /// <summary>
+    /// Determines whether the result contains a resource-not-found error.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has a resource-not-found error; otherwise, false.</returns>
     public static bool IsResourceNotFoundError(this ResultBase result)
     {
         return result.HasError<ResourceNotFoundError>();
     }
 
+    /// <summary>
+    /// Determines whether the result contains a bad-request error.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has a bad-request error; otherwise, false.</returns>
     public static bool IsBadRequestError(this ResultBase result)
     {
         return result.HasError<BadRequestFieldsError>();
     }
-    
+
+    /// <summary>
+    /// Determines whether the result contains a service-unavailable error.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has a service-unavailable error; otherwise, false.</returns>
     public static bool IsServiceUnavailableError(this ResultBase result)
     {
         return result.HasError<ServiceUnavailableError>();
     }
 
+    /// <summary>
+    /// Determines whether the result contains an internal-server-error.
+    /// </summary>
+    /// <param name="result">The result to evaluate.</param>
+    /// <returns>True if the result has an internal-server-error; otherwise, false.</returns>
     public static bool IsInternalServerError(this ResultBase result)
     {
         return result.HasError<InternalServerError>();

--- a/src/Extensions/StringExtension.cs
+++ b/src/Extensions/StringExtension.cs
@@ -16,7 +16,7 @@ public static class StringExtension
     /// <returns>The concatenated string in lowercase.</returns>
     public static string AppendString(this string stringRoot, string stringToAppend)
     {
-        return $"{stringRoot}.{stringToAppend}".ToLower();
+        return $"{stringRoot}.{stringToAppend}".ToLowerInvariant();
     }
 
     /// <summary>
@@ -25,9 +25,9 @@ public static class StringExtension
     /// <param name="value">The string to evaluate.</param>
     /// <param name="min">The minimum number of words required.</param>
     /// <returns>True if the string has at least the minimum number of words; otherwise, false.</returns>
-    public static bool HasMinhWords(this string value, int min)
+    public static bool HasMinWords(this string value, int min)
     {
-        var items = value.Split(" ");
+        var items = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return items.Length >= min;
     }
 
@@ -48,7 +48,7 @@ public static class StringExtension
     /// <returns>The parsed long value, or 0 if parsing fails.</returns>
     public static long GetLongOrDefault(this string? value)
     {
-        return !value.HasValue() ? 0 : long.Parse(value!);
+        return value.HasValue() && long.TryParse(value!, out var result) ? result : 0;
     }
 
     /// <summary>

--- a/src/Extensions/StringExtension.cs
+++ b/src/Extensions/StringExtension.cs
@@ -3,29 +3,60 @@ using FluentResults;
 
 namespace IATec.Shared.Domain.Extensions;
 
+/// <summary>
+/// Provides extension methods for string operations.
+/// </summary>
 public static class StringExtension
 {
+    /// <summary>
+    /// Appends a string to the current string separated by a dot and converts to lowercase.
+    /// </summary>
+    /// <param name="stringRoot">The base string.</param>
+    /// <param name="stringToAppend">The string to append.</param>
+    /// <returns>The concatenated string in lowercase.</returns>
     public static string AppendString(this string stringRoot, string stringToAppend)
     {
         return $"{stringRoot}.{stringToAppend}".ToLower();
     }
-    
+
+    /// <summary>
+    /// Determines whether the string has at least a minimum number of words.
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <param name="min">The minimum number of words required.</param>
+    /// <returns>True if the string has at least the minimum number of words; otherwise, false.</returns>
     public static bool HasMinhWords(this string value, int min)
     {
         var items = value.Split(" ");
         return items.Length >= min;
     }
 
+    /// <summary>
+    /// Determines whether the string has a non-whitespace value.
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <returns>True if the string is not null or whitespace; otherwise, false.</returns>
     public static bool HasValue(this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }
 
+    /// <summary>
+    /// Converts the string to a long value, returning 0 if the string is null or empty.
+    /// </summary>
+    /// <param name="value">The string to convert.</param>
+    /// <returns>The parsed long value, or 0 if parsing fails.</returns>
     public static long GetLongOrDefault(this string? value)
     {
         return !value.HasValue() ? 0 : long.Parse(value!);
     }
 
+    /// <summary>
+    /// Converts the string to camel case.
+    /// </summary>
+    /// <param name="str">The string to convert.</param>
+    /// <param name="firstUpper">If true, makes the first character lowercase.</param>
+    /// <returns>The string in camel case format.</returns>
     public static string ToCamelCase(this string str, bool firstUpper = false)
     {
         var cultInfo = new CultureInfo("en-US", false).TextInfo;
@@ -38,21 +69,43 @@ public static class StringExtension
         return str;
     }
 
+    /// <summary>
+    /// Determines whether the string is valid (not null or whitespace).
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <returns>True if the string is valid; otherwise, false.</returns>
     public static bool IsValid(this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }
 
+    /// <summary>
+    /// Validates the string and returns a FluentResults boolean.
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <returns>A <see cref="Result{T}"/> of bool indicating validity.</returns>
     public static Result<bool> IsValidResult(this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }
 
+    /// <summary>
+    /// Validates that the string is not empty.
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <returns>A <see cref="Result{T}"/> of bool indicating validity.</returns>
     public static Result<bool> IsValidNotEmpty(this string value)
     {
         return value.IsValid();
     }
 
+    /// <summary>
+    /// Validates that the string length is within the specified range.
+    /// </summary>
+    /// <param name="value">The string to evaluate.</param>
+    /// <param name="fieldMinLength">The minimum allowed length.</param>
+    /// <param name="fieldMaxLength">The maximum allowed length.</param>
+    /// <returns>A <see cref="Result{T}"/> of bool indicating whether the length is valid.</returns>
     public static Result<bool> IsValidLength(this string value, int fieldMinLength, int fieldMaxLength)
     {
         return value.Length.IsBetween(fieldMinLength, fieldMaxLength);

--- a/src/IATec.Shared.Domain.csproj
+++ b/src/IATec.Shared.Domain.csproj
@@ -11,7 +11,7 @@
         <Description>Project developed to help IATec teams to develop their projects faster.</Description>
 		<Copyright>@IATec Solutions</Copyright>
 		<RootNamespace>IATec.Shared.Domain</RootNamespace>
-        <Version>1.2.0</Version>
+        <Version>2.0.0</Version>
 		<PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
 		<PackageIcon>icon.png</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Identifies/Base/BaseIdentify.cs
+++ b/src/Identifies/Base/BaseIdentify.cs
@@ -1,6 +1,12 @@
 ﻿namespace IATec.Shared.Domain.Identifies.Base;
 
+/// <summary>
+/// Abstract base class for identification types.
+/// </summary>
 public abstract class BaseIdentify(string type)
 {
+    /// <summary>
+    /// Gets the value representing the identification type.
+    /// </summary>
     public string Value { get; private set; } = type;
 }

--- a/src/Identifies/Contexts/ContextType.cs
+++ b/src/Identifies/Contexts/ContextType.cs
@@ -1,7 +1,13 @@
 ﻿namespace IATec.Shared.Domain.Identifies.Contexts;
 
+/// <summary>
+/// Represents the context type for categorizing errors and operations.
+/// </summary>
 public class ContextType
 {
+    /// <summary>
+    /// Gets the value of the context type.
+    /// </summary>
     public string Value { get; private set; }
 
     private ContextType(string type)
@@ -9,6 +15,13 @@ public class ContextType
         Value = type;
     }
 
+    /// <summary>
+    /// Gets the Domain context type.
+    /// </summary>
     public static ContextType Domain => new("Domain");
+
+    /// <summary>
+    /// Gets the Application context type.
+    /// </summary>
     public static ContextType Application => new("Application");
 }

--- a/src/Identifies/Logging/LogActionType.cs
+++ b/src/Identifies/Logging/LogActionType.cs
@@ -1,7 +1,13 @@
 ﻿namespace IATec.Shared.Domain.Identifies.Logging;
 
+/// <summary>
+/// Represents the type of action performed in a log entry.
+/// </summary>
 public class LogActionType
 {
+    /// <summary>
+    /// Gets the value of the log action type.
+    /// </summary>
     public string Value { get; private set; }
 
     private LogActionType(string type)
@@ -9,7 +15,18 @@ public class LogActionType
         Value = type;
     }
 
+    /// <summary>
+    /// Gets the Added action type.
+    /// </summary>
     public static LogActionType Added => new("ADDED");
+
+    /// <summary>
+    /// Gets the Modified action type.
+    /// </summary>
     public static LogActionType Modified => new("MODIFIED");
+
+    /// <summary>
+    /// Gets the Deleted action type.
+    /// </summary>
     public static LogActionType Deleted => new("DELETED");
 }

--- a/src/Messages/DefaultErrorMessageKeys.cs
+++ b/src/Messages/DefaultErrorMessageKeys.cs
@@ -1,24 +1,94 @@
 ﻿namespace IATec.Shared.Domain.Messages;
 
+/// <summary>
+/// Provides default error message keys used throughout the application.
+/// </summary>
 public static class DefaultErrorMessageKeys
 {
     private const string InitialPath = "general.api.messages.";
 
+    /// <summary>
+    /// Message key for a record that cannot be deleted.
+    /// </summary>
     public const string CannotBeDeletedErrorMessageKey = $"{InitialPath}record-cannot-be-deleted";
+
+    /// <summary>
+    /// Message key for an expired token.
+    /// </summary>
     public const string ExpiredTokenMessageKey = $"{InitialPath}expired-token";
+
+    /// <summary>
+    /// Message key for an unactivated user.
+    /// </summary>
     public const string UserUnactivatedMessageKey = $"{InitialPath}user-is-unactivated";
+
+    /// <summary>
+    /// Message key for an empty field.
+    /// </summary>
     public const string EmptyFieldMessageKey = $"{InitialPath}empty-field";
+
+    /// <summary>
+    /// Message key for a record that already exists.
+    /// </summary>
     public const string AlreadyExistsMessageKey = $"{InitialPath}record-already-exists";
+
+    /// <summary>
+    /// Message key for different identifiers.
+    /// </summary>
     public const string DifferentIdentifiersMessageKey = $"{InitialPath}different-identifiers";
+
+    /// <summary>
+    /// Message key for a record that cannot be smaller.
+    /// </summary>
     public const string CannotBeSmallerMessageKey = $"{InitialPath}record-cannot-be-smaller";
+
+    /// <summary>
+    /// Message key for a record that cannot be bigger.
+    /// </summary>
     public const string CannotBeBiggerMessageKey = $"{InitialPath}record-cannot-be-bigger";
+
+    /// <summary>
+    /// Message key for a value that is empty or null.
+    /// </summary>
     public const string ValueIsEmptyOrNullMessageKey = $"{InitialPath}value-is-empty-or-null";
+
+    /// <summary>
+    /// Message key for an invalid minimum value.
+    /// </summary>
     public const string InvalidMinValueMessageKey = $"{InitialPath}invalid-min-value";
+
+    /// <summary>
+    /// Message key for an invalid range.
+    /// </summary>
     public const string InvalidRangeMessageKey = $"{InitialPath}invalid-range";
+
+    /// <summary>
+    /// Message key for an invalid length.
+    /// </summary>
     public const string InvalidLengthMessageKey = $"{InitialPath}invalid-length";
+
+    /// <summary>
+    /// Message key for invalid fields.
+    /// </summary>
     public const string InvalidFieldsMessageKey = $"{InitialPath}invalid-fields";
+
+    /// <summary>
+    /// Message key for an invalid identifier.
+    /// </summary>
     public const string InvalidIdMessageKey = $"{InitialPath}invalid-id";
+
+    /// <summary>
+    /// Message key for an invalid date.
+    /// </summary>
     public const string InvalidDateMessageKey = $"{InitialPath}invalid-date";
+
+    /// <summary>
+    /// Message key for service unavailable.
+    /// </summary>
     public const string ServiceUnavailableMessageKey = $"{InitialPath}service-unavailable";
+
+    /// <summary>
+    /// Message key for an internal server error.
+    /// </summary>
     public const string InternalServerErrorMessageKey = $"{InitialPath}internal-server-error";
 }

--- a/src/Messages/StatusCodeMessageKeys.cs
+++ b/src/Messages/StatusCodeMessageKeys.cs
@@ -1,13 +1,39 @@
 namespace IATec.Shared.Domain.Messages;
 
+/// <summary>
+/// Provides status code message keys used throughout the application.
+/// </summary>
 public static class StatusCodeMessageKeys
 {
     private const string InitialPath = "general.api.messages.status-code.";
 
+    /// <summary>
+    /// Message key for an internal server error status code.
+    /// </summary>
     public const string InternalServerErrorMessageKey = $"{InitialPath}internal-server-error";
+
+    /// <summary>
+    /// Message key for a forbidden status code.
+    /// </summary>
     public const string ForbiddenMessageKey = $"{InitialPath}forbidden";
+
+    /// <summary>
+    /// Message key for a not found status code.
+    /// </summary>
     public const string NotFoundMessageKey = $"{InitialPath}not-found";
+
+    /// <summary>
+    /// Message key for a no content status code.
+    /// </summary>
     public const string NoContentMessageKey = $"{InitialPath}no-content";
+
+    /// <summary>
+    /// Message key for a created status code.
+    /// </summary>
     public const string CreatedMessageKey = $"{InitialPath}created";
+
+    /// <summary>
+    /// Message key for an external server error status code.
+    /// </summary>
     public const string ExternalServerErrorMessageKey = $"{InitialPath}external-server-error";
 }

--- a/src/Models/LoggingAggregate/Dtos/LogCreateDto.cs
+++ b/src/Models/LoggingAggregate/Dtos/LogCreateDto.cs
@@ -1,5 +1,14 @@
 namespace IATec.Shared.Domain.Models.LoggingAggregate.Dtos;
 
+/// <summary>
+/// Data transfer object for creating a new log entry.
+/// </summary>
+/// <param name="ContainerKey">The container key associated with the log entry.</param>
+/// <param name="Source">The source of the log entry.</param>
+/// <param name="Owner">The owner associated with the log entry.</param>
+/// <param name="Action">The action performed.</param>
+/// <param name="UserId">The user identifier who performed the action.</param>
+/// <param name="Content">Optional content of the log entry.</param>
 public record LogCreateDto(
     string ContainerKey,
     string Source,

--- a/src/Models/LoggingAggregate/Dtos/LogDto.cs
+++ b/src/Models/LoggingAggregate/Dtos/LogDto.cs
@@ -1,13 +1,47 @@
 namespace IATec.Shared.Domain.Models.LoggingAggregate.Dtos;
 
+/// <summary>
+/// Data transfer object representing a log entry.
+/// </summary>
 public record LogDto
 {
-    public string Id { get; init; }
-    public string ContainerKey { get; init; }
-    public string Source { get; init; }
-    public string Owner { get; init; }
-    public string Action { get; init; }
-    public string UserId { get; init; }
+    /// <summary>
+    /// Gets the unique identifier of the log entry.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the container key associated with the log entry.
+    /// </summary>
+    public required string ContainerKey { get; init; }
+
+    /// <summary>
+    /// Gets the source of the log entry.
+    /// </summary>
+    public required string Source { get; init; }
+
+    /// <summary>
+    /// Gets the owner associated with the log entry.
+    /// </summary>
+    public required string Owner { get; init; }
+
+    /// <summary>
+    /// Gets the action performed.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Gets the user identifier who performed the action.
+    /// </summary>
+    public required string UserId { get; init; }
+
+    /// <summary>
+    /// Gets the date and time when the log entry was created.
+    /// </summary>
     public DateTime Date { get; init; }
-    public string Content { get; init; }
+
+    /// <summary>
+    /// Gets the content of the log entry.
+    /// </summary>
+    public required string Content { get; init; }
 }

--- a/src/Options/ContainerOption.cs
+++ b/src/Options/ContainerOption.cs
@@ -1,8 +1,22 @@
 namespace IATec.Shared.Domain.Options;
 
+/// <summary>
+/// Represents configuration options for a container.
+/// </summary>
 public class ContainerOption
 {
+    /// <summary>
+    /// The configuration section key for container options.
+    /// </summary>
     public const string Key = "Container";
+
+    /// <summary>
+    /// Gets the name of the container.
+    /// </summary>
     public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the unique identifier of the container.
+    /// </summary>
     public string ContainerId { get; init; } = string.Empty;
 }

--- a/src/Options/LogServiceOption.cs
+++ b/src/Options/LogServiceOption.cs
@@ -1,7 +1,17 @@
 namespace IATec.Shared.Domain.Options;
 
+/// <summary>
+/// Represents configuration options for the logging service.
+/// </summary>
 public class LogServiceOption
 {
+    /// <summary>
+    /// The configuration section key for log service options.
+    /// </summary>
     public const string Key = "IATec:Services:Log";
+
+    /// <summary>
+    /// Gets the URL of the logging service.
+    /// </summary>
     public string Url { get; init; } = string.Empty;
 }

--- a/src/Results/Errors/Base/BadRequestFieldsError.cs
+++ b/src/Results/Errors/Base/BadRequestFieldsError.cs
@@ -31,7 +31,7 @@ public class BadRequestFieldsError : Error
     {
         valueParams = TransformKeys(valueParams, type, entityName);
         Message = messageKey;
-        Metadata.Add("entityName", $"api.{type.Value}.entity.{entityName}.entity-name".ToLower());
+        Metadata.Add("entityName", $"api.{type.Value}.entity.{entityName}.entity-name".ToLowerInvariant());
         Metadata.Add("valueParams", valueParams);
     }
 
@@ -47,7 +47,7 @@ public class BadRequestFieldsError : Error
         Dictionary<string, object> result = new();
 
         foreach (var item in valueParams)
-            result.Add($"api.{type.Value}.entity.{entityName}.field.{item.Key}".ToLower(), item.Value);
+            result.Add($"api.{type.Value}.entity.{entityName}.field.{item.Key}".ToLowerInvariant(), item.Value);
 
         return result;
     }

--- a/src/Results/Errors/Base/BadRequestFieldsError.cs
+++ b/src/Results/Errors/Base/BadRequestFieldsError.cs
@@ -3,10 +3,31 @@ using IATec.Shared.Domain.Identifies.Contexts;
 
 namespace IATec.Shared.Domain.Results.Errors.Base;
 
+/// <summary>
+/// Base class for errors related to bad request field validations.
+/// </summary>
 public class BadRequestFieldsError : Error
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BadRequestFieldsError"/> class with an empty field values dictionary.
+    /// </summary>
+    /// <param name="messageKey">The message key for the error.</param>
+    /// <param name="type">The context type.</param>
+    /// <param name="entityName">The name of the entity.</param>
+    protected BadRequestFieldsError(string messageKey, ContextType type, string entityName)
+        : this(messageKey, type, entityName, new Dictionary<string, object>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BadRequestFieldsError"/> class.
+    /// </summary>
+    /// <param name="messageKey">The message key for the error.</param>
+    /// <param name="type">The context type.</param>
+    /// <param name="entityName">The name of the entity.</param>
+    /// <param name="valueParams">Dictionary of field values.</param>
     protected BadRequestFieldsError(string messageKey, ContextType type, string entityName,
-        Dictionary<string, object>? valueParams = null)
+        Dictionary<string, object> valueParams)
     {
         valueParams = TransformKeys(valueParams, type, entityName);
         Message = messageKey;
@@ -14,12 +35,16 @@ public class BadRequestFieldsError : Error
         Metadata.Add("valueParams", valueParams);
     }
 
-    private static Dictionary<string, object> TransformKeys(Dictionary<string, object>? valueParams, ContextType type,
-        string entityName)
+    /// <summary>
+    /// Transforms the field keys into a standardized API format.
+    /// </summary>
+    /// <param name="valueParams">The dictionary of field values.</param>
+    /// <param name="type">The context type.</param>
+    /// <param name="entityName">The name of the entity.</param>
+    /// <returns>A new dictionary with transformed keys.</returns>
+    private static Dictionary<string, object> TransformKeys(Dictionary<string, object> valueParams, ContextType type, string entityName)
     {
         Dictionary<string, object> result = new();
-
-        if (valueParams is null) return result;
 
         foreach (var item in valueParams)
             result.Add($"api.{type.Value}.entity.{entityName}.field.{item.Key}".ToLower(), item.Value);

--- a/src/Results/Errors/Default/EmptyFieldError.cs
+++ b/src/Results/Errors/Default/EmptyFieldError.cs
@@ -4,6 +4,9 @@ using IATec.Shared.Domain.Results.Errors.Base;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error that occurs when a required field is empty.
+/// </summary>
 public class EmptyFieldError(string entity, string fieldName, ContextType type)
     : BadRequestFieldsError(DefaultErrorMessageKeys.EmptyFieldMessageKey, type, entity,
         new Dictionary<string, object> {{fieldName, string.Empty}});

--- a/src/Results/Errors/Default/EntityNotFoundError.cs
+++ b/src/Results/Errors/Default/EntityNotFoundError.cs
@@ -4,5 +4,8 @@ using IATec.Shared.Domain.Results.Errors.Base;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error that occurs when an entity is not found.
+/// </summary>
 public class EntityNotFoundError(string entity)
-    : BadRequestFieldsError(DefaultErrorMessageKeys.EmptyFieldMessageKey, ContextType.Domain, entity);
+    : BadRequestFieldsError(DefaultErrorMessageKeys.EmptyFieldMessageKey, ContextType.Domain, entity, new());

--- a/src/Results/Errors/Default/InternalServerError.cs
+++ b/src/Results/Errors/Default/InternalServerError.cs
@@ -3,6 +3,10 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error indicating an internal server error has occurred.
+/// </summary>
 public sealed class InternalServerError(
     string? message = null) : Error(message ?? DefaultErrorMessageKeys.InternalServerErrorMessageKey)
-{ }
+{
+}

--- a/src/Results/Errors/Default/InvalidFieldError.cs
+++ b/src/Results/Errors/Default/InvalidFieldError.cs
@@ -4,6 +4,9 @@ using IATec.Shared.Domain.Results.Errors.Base;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error that occurs when a field has an invalid value.
+/// </summary>
 public class InvalidFieldError(
     string entity,
     string fieldName,

--- a/src/Results/Errors/Default/InvalidLengthError.cs
+++ b/src/Results/Errors/Default/InvalidLengthError.cs
@@ -4,6 +4,9 @@ using IATec.Shared.Domain.Results.Errors.Base;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error that occurs when a field value length is outside the allowed range.
+/// </summary>
 public class InvalidLengthError(
     string entity,
     string fieldName,

--- a/src/Results/Errors/Default/InvalidMinValueError.cs
+++ b/src/Results/Errors/Default/InvalidMinValueError.cs
@@ -4,6 +4,9 @@ using IATec.Shared.Domain.Results.Errors.Base;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error that occurs when a field value is below the minimum allowed value.
+/// </summary>
 public class InvalidMinValueError(
     string entity,
     string fieldName,

--- a/src/Results/Errors/Default/ResourceNotFoundError.cs
+++ b/src/Results/Errors/Default/ResourceNotFoundError.cs
@@ -3,8 +3,14 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error indicating that a requested resource was not found.
+/// </summary>
 public class ResourceNotFoundError : Error
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceNotFoundError"/> class.
+    /// </summary>
     public ResourceNotFoundError()
     {
         Message = StatusCodeMessageKeys.NotFoundMessageKey;

--- a/src/Results/Errors/Default/ServiceUnavailableError.cs
+++ b/src/Results/Errors/Default/ServiceUnavailableError.cs
@@ -3,8 +3,14 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Errors.Default;
 
+/// <summary>
+/// Represents an error indicating that a service is unavailable.
+/// </summary>
 public class ServiceUnavailableError : Error
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceUnavailableError"/> class.
+    /// </summary>
     public ServiceUnavailableError()
     {
         Message = DefaultErrorMessageKeys.ServiceUnavailableMessageKey;

--- a/src/Results/Successes/Default/CreatedSuccess.cs
+++ b/src/Results/Successes/Default/CreatedSuccess.cs
@@ -3,8 +3,15 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Successes.Default;
 
+/// <summary>
+/// Represents a success result indicating that a resource was created.
+/// </summary>
 public class CreatedSuccess : Success
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreatedSuccess"/> class.
+    /// </summary>
+    /// <param name="resourceId">The unique identifier of the created resource.</param>
     public CreatedSuccess(int resourceId)
     {
         Metadata.Add("id", resourceId);

--- a/src/Results/Successes/Default/EmptyResult.cs
+++ b/src/Results/Successes/Default/EmptyResult.cs
@@ -3,8 +3,15 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Successes.Default;
 
+/// <summary>
+/// Represents an empty result with a no-content success message.
+/// </summary>
 public class EmptyResult : Result
 {
+    /// <summary>
+    /// Gets a successful result with a no-content success message.
+    /// </summary>
+    /// <returns>A successful <see cref="Result"/> with no content.</returns>
     public static Result GetResult()
     {
         return Ok().WithSuccess(StatusCodeMessageKeys.NoContentMessageKey);

--- a/src/Results/Successes/Default/NoContentSuccess.cs
+++ b/src/Results/Successes/Default/NoContentSuccess.cs
@@ -3,8 +3,14 @@ using IATec.Shared.Domain.Messages;
 
 namespace IATec.Shared.Domain.Results.Successes.Default;
 
+/// <summary>
+/// Represents a success result indicating a no-content response.
+/// </summary>
 public class NoContentSuccess : Success
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoContentSuccess"/> class.
+    /// </summary>
     public NoContentSuccess()
     {
         Message = StatusCodeMessageKeys.NoContentMessageKey;

--- a/src/SeedWorks/Entity.cs
+++ b/src/SeedWorks/Entity.cs
@@ -3,27 +3,54 @@ using IATec.Shared.Domain.Identifies.Base;
 
 namespace IATec.Shared.Domain.SeedWorks;
 
+/// <summary>
+/// Abstract base class for all domain entities with a generic identifier type.
+/// </summary>
+/// <typeparam name="T">The type of the entity identifier.</typeparam>
 public abstract class Entity<T> : IEntity
 {
+    /// <summary>
+    /// Gets or sets the unique identifier of the entity.
+    /// </summary>
     public virtual T? Id { get; set; }
 
+    /// <summary>
+    /// Determines whether the entity identifier is unassigned or default.
+    /// </summary>
+    /// <returns>True if the identifier is unassigned; otherwise, false.</returns>
     public abstract bool IsUnassigned();
 
+    /// <summary>
+    /// Gets the source type of the entity for identification purposes.
+    /// </summary>
+    /// <returns>The source type identifier, or null if not defined.</returns>
     public virtual BaseIdentify? GetSourceType()
     {
         return null;
     }
 
+    /// <summary>
+    /// Gets the content to be logged for this entity.
+    /// </summary>
+    /// <returns>The log content object, or null if not defined.</returns>
     public virtual object? GetLogContent()
     {
         return null;
     }
 
+    /// <summary>
+    /// Gets the owner identifier of the entity.
+    /// </summary>
+    /// <returns>A string representing the owner.</returns>
     public virtual string GetOwner()
     {
         return string.Empty;
     }
 
+    /// <summary>
+    /// Returns a string representation of the entity.
+    /// </summary>
+    /// <returns>A string that represents the entity including its type name and identifier.</returns>
     public override string ToString()
     {
         return $"{GetType().Name} [Id={Id}]";

--- a/src/SeedWorks/EntityInt32.cs
+++ b/src/SeedWorks/EntityInt32.cs
@@ -1,12 +1,23 @@
 namespace IATec.Shared.Domain.SeedWorks;
 
+/// <summary>
+/// Represents an entity with a 32-bit integer identifier.
+/// </summary>
 public class EntityInt32 : Entity<int>
 {
+    /// <summary>
+    /// Gets the owner identifier, which is the entity's Id.
+    /// </summary>
+    /// <returns>A string representing the owner identifier.</returns>
     public override string GetOwner()
     {
         return $"{Id}";
     }
 
+    /// <summary>
+    /// Determines whether the entity identifier is unassigned (equal to zero).
+    /// </summary>
+    /// <returns>True if the identifier is zero; otherwise, false.</returns>
     public override bool IsUnassigned()
     {
         return Id == 0;

--- a/src/SeedWorks/EntityNullable.cs
+++ b/src/SeedWorks/EntityNullable.cs
@@ -1,12 +1,23 @@
 namespace IATec.Shared.Domain.SeedWorks;
 
+/// <summary>
+/// Represents an entity with a nullable string identifier.
+/// </summary>
 public class EntityNullable : Entity<string?>
 {
+    /// <summary>
+    /// Gets the owner identifier, which is the entity's Id.
+    /// </summary>
+    /// <returns>A string representing the owner identifier.</returns>
     public override string GetOwner()
     {
         return $"{Id}";
     }
 
+    /// <summary>
+    /// Determines whether the entity identifier is unassigned (null or empty).
+    /// </summary>
+    /// <returns>True if the identifier is null or empty; otherwise, false.</returns>
     public override bool IsUnassigned()
     {
         return string.IsNullOrEmpty(Id);

--- a/src/SeedWorks/EntityUlidInt32.cs
+++ b/src/SeedWorks/EntityUlidInt32.cs
@@ -1,14 +1,28 @@
 namespace IATec.Shared.Domain.SeedWorks;
 
+/// <summary>
+/// Represents an entity with a 32-bit integer identifier and an external ULID.
+/// </summary>
 public class EntityUlidInt32 : Entity<int>
 {
+    /// <summary>
+    /// Gets the external unique identifier generated as a ULID.
+    /// </summary>
     public string ExternalId { get; private set; } = Ulid.NewUlid().ToString();
-    
+
+    /// <summary>
+    /// Gets the owner identifier, which is the entity's Id.
+    /// </summary>
+    /// <returns>A string representing the owner identifier.</returns>
     public override string GetOwner()
     {
         return $"{Id}";
     }
-    
+
+    /// <summary>
+    /// Determines whether the entity identifier is unassigned (equal to zero).
+    /// </summary>
+    /// <returns>True if the identifier is zero; otherwise, false.</returns>
     public override bool IsUnassigned()
     {
         return Id == 0;


### PR DESCRIPTION
## [2.0.0] - 2025-05-20

### BREAKING CHANGES
- `BadRequestFieldsError` constructor parameter `valueParams` changed from `Dictionary<string, object>?` (nullable) to `Dictionary<string, object>` (non-nullable). Code calling this constructor with an explicit `null` will fail to compile.
- Removed nullable collection (`Dictionary?`) definitions in favor of initializing empty collections.

### ADDED
- Added comprehensive XML documentation summaries to all public classes, methods, properties, and interfaces.
- Added a new overload of `BadRequestFieldsError` without a dictionary parameter, defaulting to an empty collection.

### CHANGED
- `EntityNotFoundError` now explicitly passes an empty dictionary to the base constructor.

### FIXED
- Fixed malformed XML documentation tags (`<see cref="Result{T}"/>`) in `StringExtension` methods.
- Fixed incorrect constructor summary in `BadRequestFieldsError` overload.