### PR TITLE
FT 696503 - fix: remove required from log properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+For project overview and usage examples, see the [README](README.md) .
+
+## [2.0.1] - 2026-05-26
+
+### FIXED
+- Remove `required` modifier from log properties in `LogDto` and `LogCreateDto`.
+
 ## [2.0.0] - 2026-05-20
 
 ### BREAKING CHANGES

--- a/src/IATec.Shared.Domain.csproj
+++ b/src/IATec.Shared.Domain.csproj
@@ -11,7 +11,7 @@
         <Description>Project developed to help IATec teams to develop their projects faster.</Description>
 		<Copyright>@IATec Solutions</Copyright>
 		<RootNamespace>IATec.Shared.Domain</RootNamespace>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
 		<PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
 		<PackageIcon>icon.png</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Models/LoggingAggregate/Dtos/LogDto.cs
+++ b/src/Models/LoggingAggregate/Dtos/LogDto.cs
@@ -8,7 +8,7 @@ public record LogDto
     /// <summary>
     /// Gets the unique identifier of the log entry.
     /// </summary>
-    public required string Id { get; init; }
+    public string? Id { get; init; }
 
     /// <summary>
     /// Gets the container key associated with the log entry.
@@ -33,7 +33,7 @@ public record LogDto
     /// <summary>
     /// Gets the user identifier who performed the action.
     /// </summary>
-    public required string UserId { get; init; }
+    public string? UserId { get; init; }
 
     /// <summary>
     /// Gets the date and time when the log entry was created.


### PR DESCRIPTION
## [2.0.1] - 2026-05-26

### FIXED
- Remove `required` modifier from log properties in `LogDto` and `LogCreateDto`.